### PR TITLE
Small clarification to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this to your beancount journal, and start fava as normal
 2000-01-01 custom "fava-extension" "fava_envelope" "{}"
 ```
 
-You should now see 'Envelope' in your fava window
+You should now see 'Envelope' in your fava window. You must set up a budget (see below), or else Fava will report a 404 error.
 
 ## Setting up budget
 


### PR DESCRIPTION
Clarification that it is not enough to enable the extension in order to test is out. One must also create a budget.

I have seen several people report having issues trying out the extension (in Issues, or the Beancount mailing list), and judging by my own mistake, this could have been because people did not set up a budget.