### PR TITLE
Adding multiple budgets in multiple currencies capacity to fava_envelope

### DIFF
--- a/example.beancount
+++ b/example.beancount
@@ -10,6 +10,10 @@ option "operating_currency" "USD"
 2010-01-01 custom "fava-extension" "fava_envelope" "{}"
 2010-01-01 custom "envelope" "start date" "2015-01"
 2010-01-01 custom "envelope" "budget account" "Assets:US:BofA:Checking"
+2015-01-01 custom "envelope" "repeating" "Expenses:Financial:Fees" 4
+2015-01-01 custom "envelope" "allocate" "Expenses:Health:Dental:Insurance" 5.80
+2017-06-01 custom "envelope" "allocate" "Expenses:Financial:Fees" 0
+
 
 * Commodities
 

--- a/fava_envelope/__init__.py
+++ b/fava_envelope/__init__.py
@@ -34,9 +34,9 @@ class EnvelopeBudget(FavaExtensionBase):
         
     
     def get_currencies(self):
-        try:
+        if currencies in self.config:
             return self.config["currencies"]
-        except:
+        else:
             return None
     
     

--- a/fava_envelope/__init__.py
+++ b/fava_envelope/__init__.py
@@ -5,24 +5,42 @@ from fava.ext import FavaExtensionBase
 from beancount.core.number import Decimal, D
 
 from .modules.beancount_envelope import BeancountEnvelope
-
+import ast
 
 class EnvelopeBudget(FavaExtensionBase):
     '''
     '''
     report_title = "Envelope Budget"
 
-    def generate_budget_df(self):
+    def generate_budget_df(self,currency):
+        self.currency=currency
         module = BeancountEnvelope(
             self.ledger.entries,
-            self.ledger.options
+            self.ledger.options,
+            self.currency
         )
-        self.income_tables, self.envelope_tables = module.envelope_tables()
+        self.income_tables, self.envelope_tables, self.currency = module.envelope_tables()
 
-    def get_budgets_months_available(self):
-        self.generate_budget_df()
+    def get_budgets_months_available(self,currency):
+        self.generate_budget_df(currency)
         return self.income_tables.columns
 
+    def check_month_in_available_months(self,month,currency):
+        if currency and month:
+            if month in self.get_budgets_months_available(currency):
+                return True
+        return False
+        
+        
+    
+    def get_currencies(self):
+        titles=[]
+        try:
+            return self.config["currencies"]
+        except:
+            return None
+    
+    
     def generate_income_query_tables(self, month):
 
         income_table_types = []

--- a/fava_envelope/__init__.py
+++ b/fava_envelope/__init__.py
@@ -34,7 +34,7 @@ class EnvelopeBudget(FavaExtensionBase):
         
     
     def get_currencies(self):
-        if currencies in self.config:
+        if "currencies" in self.config:
             return self.config["currencies"]
         else:
             return None

--- a/fava_envelope/__init__.py
+++ b/fava_envelope/__init__.py
@@ -34,7 +34,6 @@ class EnvelopeBudget(FavaExtensionBase):
         
     
     def get_currencies(self):
-        titles=[]
         try:
             return self.config["currencies"]
         except:

--- a/fava_envelope/modules/main.py
+++ b/fava_envelope/modules/main.py
@@ -19,11 +19,12 @@ def main():
 
     # Read beancount input file
     entries, errors, options_map = loader.load_file(args.filename)
-    ext = BeancountEnvelope(entries, options_map)
-    df1, df2 = ext.envelope_tables()
+    ext = BeancountEnvelope(entries, options_map, None)
+    df1, df2, df3 = ext.envelope_tables()
     #logging.info(df)
     print(df1)
     print(df2)
+    print(df3)
 
 
 if __name__ == '__main__':

--- a/fava_envelope/templates/EnvelopeBudget.html
+++ b/fava_envelope/templates/EnvelopeBudget.html
@@ -1,17 +1,29 @@
 {% import "_query_table.html" as querytable with context %}
-
-<i>Envelope Budget</i>
-
-{% set month = request.args.get('month') %}
-{% if month == None%}
-{% set month = extension.get_budgets_months_available()[-1] %}
+{% set currency = request.args.get('currency') %}
+{% if currency == None%}
+{% set currency = extension.get_currencies()[0]%}
 {% endif %}
+{% if extension.check_month_in_available_months(request.args.get('month'),currency) %}
+{% set month = request.args.get('month') %}
+{% endif %}
+{% if not month%}
+{% set month = extension.get_budgets_months_available(currency)[-1] %}
+{% endif %}
+{% if extension.get_currencies() %}
 <div class="headerline">
-  {% for m in extension.get_budgets_months_available() %}
-  <h3><b>{% if not (module == m) %}<a href="{{ url_for_current(month=m) }}">{{ m }}</a>{% else %} {{ m }}{% endif %}</b></h3>
+  {% for c in extension.get_currencies() %}
+  <h3><b>{% if not (currency == c) %}<a href="{{ url_for_current(month=month,currency=c) }}">Envelope Budget {{ c }}</a>{% else %}Envelope Budget {{ c }}{% endif %}</b></h3>
   {% endfor %}
 </div>
+{% endif %}
 
+<h3>{{ title }}</h3>
+
+<div class="headerline">
+  {% for m in extension.get_budgets_months_available(currency) %}
+  <h3><b>{% if not (module == m) %}<a href="{{ url_for_current(month=m,currency=currency) }}">{{ m }}</a>{% else %} {{ m }}{% endif %}</b></h3>
+  {% endfor %}
+</div>
 <h3>{{ month }}</h3>
 
 {% set income_table = extension.generate_income_query_tables(month) %}


### PR DESCRIPTION
As per my issue remark, and just in case of interest, these code tidbits allow fava_envelope to optionally operate over multiple currencies.

In the declaration of the fava extension, an option is added, a dictionary entry for key 'currencies', which is a list of currencies (for example

2021-04-01 custom "fava-extension" "fava_envelope" "{'currencies':['GBP', 'QAR']}"

custom options are then set per currency by using the keyword "envelopeCUR" (for instance, "envelopeUSD" or "envelopeGBP".

Two additional options I've added are "income account" (to consider some accounts as Income when they are used for international transfers) and "currency" (to set the currency for a single currency account when one doesn't want to use the first operating_currency from the beancount list).