### PR TITLE
fix: replace url_for_current with url_for

### DIFF
--- a/fava_envelope/templates/EnvelopeBudget.html
+++ b/fava_envelope/templates/EnvelopeBudget.html
@@ -13,7 +13,7 @@
 {% if extension.get_currencies() %}
 <div class="headerline">
   {% for c in extension.get_currencies() %}
-  <h3><b>{% if not (currency == c) %}<a href="{{ url_for_current(month=month,currency=c) }}">Envelope Budget {{ c }}</a>{% else %}Envelope Budget {{ c }}{% endif %}</b></h3>
+  <h3><b>{% if not (currency == c) %}<a href="{{ url_for('extension_report', report_name='EnvelopeBudget', month=month,currency=c) }}">Envelope Budget {{ c }}</a>{% else %}Envelope Budget {{ c }}{% endif %}</b></h3>
   {% endfor %}
 </div>
 {% endif %}
@@ -22,7 +22,7 @@
 
 <div class="headerline">
   {% for m in extension.get_budgets_months_available(currency) %}
-  <h3><b>{% if not (module == m) %}<a href="{{ url_for_current(month=m,currency=currency) }}">{{ m }}</a>{% else %} {{ m }}{% endif %}</b></h3>
+  <h3><b>{% if not (module == m) %}<a href="{{ url_for('extension_report', report_name='EnvelopeBudget', month=m,currency=currency) }}">{{ m }}</a>{% else %} {{ m }}{% endif %}</b></h3>
   {% endfor %}
 </div>
 <h3>{{ month }}</h3>


### PR DESCRIPTION
 Upgrade to fava 1.20 breaks the extension, as it depends on the `url_for_current` function, that was apparently removed. This PR replaces the `url_for_current` shorthand with the more verbose `url_for`, allowing an upgrade to fava 1.20.