### PR TITLE
Support copy-on-write for Pandas 3.0

### DIFF
--- a/src/fava_envelope/modules/beancount_envelope.py
+++ b/src/fava_envelope/modules/beancount_envelope.py
@@ -153,7 +153,7 @@ class BeancountEnvelope:
             if any(regexp.match(row[0]) for regexp in self.budget_accounts):
                 if len(row) > 1 and row[1] is not None:
                     starting_balance += row[1]
-        self.income_df[months[0]]["Avail Income"] += starting_balance
+        self.income_df.loc["Avail Income", months[0]] += starting_balance
 
         self.envelope_df.fillna(Decimal(0.00), inplace=True)
 
@@ -161,7 +161,7 @@ class BeancountEnvelope:
         for index, row in self.envelope_df.iterrows():
             for index2, month in enumerate(months):
                 if index2 == 0:
-                    self.envelope_df[month, "available"][index] = (
+                    self.envelope_df.loc[index, (month, "available")] = (
                         row[month, "budgeted"] + row[month, "activity"]
                     )
                 else:
@@ -169,13 +169,13 @@ class BeancountEnvelope:
                         months[index2 - 1], "available"
                     ][index]
                     if prev_available > 0 or self.negative_rollover:
-                        self.envelope_df[month, "available"][index] = (
+                        self.envelope_df.loc[index, (month, "available")] = (
                             prev_available
                             + row[month, "budgeted"]
                             + row[month, "activity"]
                         )
                     else:
-                        self.envelope_df[month, "available"][index] = (
+                        self.envelope_df.loc[index, (month, "available")] = (
                             row[month, "budgeted"] + row[month, "activity"]
                         )
 


### PR DESCRIPTION
Running the extension generates pandas warnings of the kind:
```
fava_envelope/modules/beancount_envelope.py:156: FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
A typical example is when you are setting values in a column of a DataFrame, like:

df["col"][row_indexer] = value

Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy

  self.income_df[months[0]]["Avail Income"] += starting_balance
```

This PR changes the implementation to support new Pandas defaults.